### PR TITLE
chore: several optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ jobs:
           override-file-path: "<Your SQL review rules configuration file path>"
           template-id: "<SQL review rule template id>"
           database-type: "<The database type>"
+          file-pattern: "<The file pattern for your SQL files>"
 ```
 
 The action will be triggered in any pull request which has SQL files changed. It will call the SQL review service to check if the change is valid according to the SQL review rules.
@@ -28,14 +29,16 @@ The action will be triggered in any pull request which has SQL files changed. It
 ### About parameters
 
 - `database-type`: **Required**. The database type, should be one of `MYSQL`, `POSTGRES` or `TIDB`.
-- `override-file-path`: **Optional**. Your SQL review rules configuration file path. You can configure and generate this file in [Bytebase SQL Review Guide](https://www.bytebase.com/sql-review-guide) page. You can ignore this parameter and only provide the template id if you don't want to customize rules.
+- `override-file-path`: **Optional**. Your SQL review rules configuration file path. You can configure and generate this file in [Bytebase SQL Review Guide](https://www.bytebase.com/sql-review-guide) page. You can ignore this parameter and only provide the `template-id` if you don't want to customize rules.
 - `template-id`: **Optional**. The SQL Review rule template id, should be one of [`bb.sql-review.prod`](https://bytebase.com//sql-review-guide?templateId=bb.sql-review.prod) or [`bb.sql-review.dev`](https://bytebase.com//sql-review-guide?templateId=bb.sql-review.dev). You can ignore this parameter if you provide the `override-file-path` parameter.
+- `file-pattern`: **Optional**. The file path pattern for your SQL files. Defaults `^.*\.sql$`.
 
-## Example
+## Examples
 
 Once you configure the action, you can get these error or warning message based on your SQL review rules:
 
 ![example](./assets/example.webp)
 
-- Go to the [`./example/`](./example/) folder to see how to configure the workflow and override SQL review rules.
-- Go to [bytebase](https://github.com/bytebase/bytebase/tree/main/.github/workflows) for a real example.
+- Go to the [`./example`](./example/) folder to see how to configure the workflow and override SQL review rules.
+- Check this PR [chore: add sql review action](https://github.com/Bytebase/Bytebase/pull/2100) to see how to add this action into your repository.
+- Check this PR [chore: add test sql](https://github.com/Bytebase/Bytebase/pull/2177/files) to see how this action works in your pull request.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The action will be triggered in any pull request which has SQL files changed. It
 - `database-type`: **Required**. The database type, should be one of `MYSQL`, `POSTGRES` or `TIDB`.
 - `override-file-path`: **Optional**. Your SQL review rules configuration file path. You can configure and generate this file in [Bytebase SQL Review Guide](https://www.bytebase.com/sql-review-guide) page. You can ignore this parameter and only provide the `template-id` if you don't want to customize rules.
 - `template-id`: **Optional**. The SQL Review rule template id, should be one of [`bb.sql-review.prod`](https://bytebase.com//sql-review-guide?templateId=bb.sql-review.prod) or [`bb.sql-review.dev`](https://bytebase.com//sql-review-guide?templateId=bb.sql-review.dev). You can ignore this parameter if you provide the `override-file-path` parameter.
-- `file-pattern`: **Optional**. The file path pattern for your SQL files. Defaults `^.*\.sql$`.
+- `file-pattern`: **Optional**. The file path regex pattern for your SQL files. Defaults `^.*\.sql$`. For example, if you only want to subscribe to the SQL file changes in the `db` folder, you can set this parameter to `^db/.*\.sql$`.
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -11,18 +11,22 @@ inputs:
   template-id:
     description: 'The SQL check template id, required if the override is not specified. Should be one of "bb.sql-review.prod", "bb.sql-review.dev".'
     required: false
+  file-pattern:
+    description: 'The file path pattern for your SQL files. Defaults "^.*\.sql$"'
+    required: false
+    default: '^.*\.sql$'
 runs:
   using: "composite"
   steps:
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v23.2
+      uses: umani/changed-files@v3.3.0
       with:
-        files: |
-          **/*.sql
+        repo-token: ${{ github.token }}
+        pattern: "${{ inputs.file-pattern }}"
     - name: SQL Review
       run: |
-        $GITHUB_ACTION_PATH/main.sh --files="${{ steps.changed-files.outputs.all_changed_files }}" --database-type=${{ inputs.database-type }} --override-file="${{ inputs.override-file-path }}" --template-id="${{ inputs.template-id }}"
+        $GITHUB_ACTION_PATH/main.sh --files="${{ steps.changed-files-exporter.outputs.files_created }} ${{ steps.changed-files-exporter.outputs.files_updated }}" --database-type=${{ inputs.database-type }} --override-file="${{ inputs.override-file-path }}" --template-id="${{ inputs.template-id }}"
       shell: bash
 branding:
   icon: "database"

--- a/main.sh
+++ b/main.sh
@@ -29,7 +29,8 @@ case $i in
 esac
 done
 
-DOC_URL=https://www.bytebase.com/docs/reference/error-code/advisor
+# Use BB_SQL_API from environment as default value.
+# Users can deploy their own SQL Service from https://github.com/Bytebase/Bytebase/blob/main/Dockerfile.sql-service, thus they can get their own SQL check API and inject it into the repo's environment
 API_URL=$BB_SQL_API
 if [ -z $API_URL ]
 then
@@ -50,7 +51,6 @@ fi
 
 result=0
 for FILE in $FILES; do
-    # The action tj-actions/changed-files has a bug. When no files match the pattern, it will return all changed files
     if [[ $FILE =~ \.sql$ ]]; then
         echo "Start check statement in file $FILE"
         $GITHUB_ACTION_PATH/sql-review.sh --file=$FILE --database-type=$DATABASE_TYPE --override="$override" --template-id="$TEMPLATE_ID" --api=$API_URL

--- a/sql-review.sh
+++ b/sql-review.sh
@@ -74,6 +74,7 @@ while read status code title content; do
 
     if [ $code != 0 ]; then
         title="$title ($code)"
+        # To indent the output message
         content="$content
 Doc: $DOC_URL#$code"
         content="${content//$'\n'/'%0A'}"


### PR DESCRIPTION
### Use `umani/changed-files` instead of `tj-actions/changed-files` to get changed files

The action `tj-actions/changed-files` has a bug, it will output all changed files if no file matches the `**/*.sql` pattern. I have reported [the issue](https://github.com/tj-actions/changed-files/issues/565) but haven't been fixed yet. (the author's fix only removes the warning log, not actually fixed this issue.)

### Add `file-pattern` parameter

**Optional**. Users can set the target SQL files. For example, if they only want to subscribe to the SQL file changes in the `db` folder, they can set this parameter to `^db/.*\.sql$`.

### Update the README

Link our PRs as example.