### PR TITLE
chore: release 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check SQL
-        uses: bytebase/sql-review-action@0.0.1
+        uses: bytebase/sql-review-action@0.0.2
         with:
           override-file-path: "<Your SQL review rules configuration file path>"
           template-id: "<SQL review rule template id>"

--- a/example/.github/workflows/sql-review.yml
+++ b/example/.github/workflows/sql-review.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check SQL
-        uses: bytebase/sql-review-action@0.0.1
+        uses: bytebase/sql-review-action@0.0.2
         with:
           override-file-path: ./sql-review-override.yml
           database-type: POSTGRES

--- a/sql-review.sh
+++ b/sql-review.sh
@@ -77,6 +77,10 @@ while read status code title content; do
         # To indent the output message
         content="$content
 Doc: $DOC_URL#$code"
+
+        echo "### [$status] $title" >> $GITHUB_STEP_SUMMARY
+        echo "$content" >> $GITHUB_STEP_SUMMARY
+
         content="${content//$'\n'/'%0A'}"
         error_msg="file=$FILE,line=1,col=1,endColumn=2,title=$title::$content"
 


### PR DESCRIPTION
- Release 0.0.2
- A small change: add the action summary.

Action output message cannot hyperlink the docs URL, users have to copy the link by themselves. By adding the summary, they can easily open the docs with a click.

<img width="1367" alt="图片" src="https://user-images.githubusercontent.com/10706318/183557735-90f79154-79eb-460b-91d2-6ba179e7aae6.png">
